### PR TITLE
correction for hf_best_cov function with catchments contained by other catchments

### DIFF
--- a/R/hf_best_cov.R
+++ b/R/hf_best_cov.R
@@ -147,6 +147,7 @@ hf_best_cov <- function (inputFolder,
         similarCatch <- similarCatch[-1, ] 
       }
       i <- nrow(similarCatch)
+      UniquecatchShp <- UniquecatchShp[UniquecatchShp$totalpop > 0,] 
       setTxtProgressBar(bar, nrow(simi) - i)
     }
     close(bar)

--- a/R/hf_best_cov.R
+++ b/R/hf_best_cov.R
@@ -288,6 +288,7 @@ hf_best_cov <- function (inputFolder,
           }
         }
       }
+      #Remove the catchments that have been set to 0 population.
       tempCatchUnique <- tempCatchUnique[tempCatchUnique$totalpop > 0,]
       setTxtProgressBar(bar, ceiling((((i - 1) * 100) / nTot) + (k * 100 / nTot) / nrow(tempCatchUnique)))
     }

--- a/R/hf_best_cov.R
+++ b/R/hf_best_cov.R
@@ -288,6 +288,7 @@ hf_best_cov <- function (inputFolder,
           }
         }
       }
+      tempCatchUnique <- tempCatchUnique[tempCatchUnique$totalpop > 0,]
       setTxtProgressBar(bar, ceiling((((i - 1) * 100) / nTot) + (k * 100 / nTot) / nrow(tempCatchUnique)))
     }
   }


### PR DESCRIPTION
Addition of a line that removes the catchments that are contained by a catchment that was selected as being the best.
Before that, these catchments were only set to 0 population but actually not removed.